### PR TITLE
Remove obsolete container packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:alpine
 
-RUN ["apk", "add", "gcc", "musl-dev", "libffi-dev", "openssl-dev", "libxml2-dev", "libxslt-dev", "rust", "cargo"]
-
 WORKDIR /app
 COPY requirements.txt .
 RUN ["pip", "install", "-r", "/app/requirements.txt" ]


### PR DESCRIPTION
As pip now ships binary packages that natively link to musl (which is used in Alpine) instead of glibc, there is no need to compile them at installation time. Thus, there is no need to install compiler toolchains and development libraries in the docker image.